### PR TITLE
Lexer: Mathematical Operators, Equal sign and Identifier Bug Fix

### DIFF
--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -102,6 +102,23 @@ pub enum Token {
     #[token("%")]
     Percent,
 
+    /// The equals operator (`=`).
+    /// 
+    /// ```
+    /// use flycatcher_lexer::Logos;
+    /// use flycatcher_lexer::Token;
+    /// 
+    /// let mut lexer = Token::lexer("my_iden = 2");
+    /// assert_eq!(lexer.next(), Some(Token::Identifier));
+    /// assert_eq!(lexer.slice(), "my_iden");
+    /// assert_eq!(lexer.next(), Some(Token::Equals));
+    /// assert_eq!(lexer.slice(), "=");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "2");
+    /// ```
+    #[token("=")]
+    Equals,
+
     /// A number literal that supports integers and floating point numbers, with an optional
     /// mantissa (exponent).
     /// 
@@ -148,7 +165,7 @@ pub enum Token {
     /// assert_eq!(lexer.next(), Some(Token::Identifier));
     /// assert_eq!(lexer.slice(), "Hello");
     /// ```
-    #[regex(r"[a-zA-Z_$][a-zA-Z0-9]*")]
+    #[regex(r"[a-zA-Z_$][a-zA-Z_0-9]*")]
     Identifier,
 
     /// This token matches any whitespace character, including regular whitespaces, tabs and

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -165,7 +165,7 @@ pub enum Token {
     /// assert_eq!(lexer.next(), Some(Token::Identifier));
     /// assert_eq!(lexer.slice(), "Hello");
     /// ```
-    #[regex(r"[a-zA-Z_$][a-zA-Z_0-9]*")]
+    #[regex(r"[a-zA-Z_$][a-zA-Z_$0-9]*")]
     Identifier,
 
     /// This token matches any whitespace character, including regular whitespaces, tabs and

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -17,6 +17,91 @@ pub use logos::{Lexer, Logos};
 #[derive(Clone, Debug, Logos, PartialEq)]
 pub enum Token {
 
+    /// The plus (`+`) operator.
+    /// 
+    /// ```
+    /// use flycatcher_lexer::Logos;
+    /// use flycatcher_lexer::Token;
+    /// 
+    /// let mut lexer = Token::lexer("21 + 21");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "21");
+    /// assert_eq!(lexer.next(), Some(Token::Plus));
+    /// assert_eq!(lexer.slice(), "+");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "21");
+    /// ```
+    #[token("+")]
+    Plus,
+
+    /// The dash/hyphen/minus (`-`) operator.
+    /// 
+    /// ```
+    /// use flycatcher_lexer::Logos;
+    /// use flycatcher_lexer::Token;
+    /// 
+    /// let mut lexer = Token::lexer("21 - 21");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "21");
+    /// assert_eq!(lexer.next(), Some(Token::Dash));
+    /// assert_eq!(lexer.slice(), "-");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "21");
+    /// ```
+    #[token("-")]
+    Dash,
+
+    /// The star/asterisk/multiply (`*`) operator.
+    /// 
+    /// ```
+    /// use flycatcher_lexer::Logos;
+    /// use flycatcher_lexer::Token;
+    /// 
+    /// let mut lexer = Token::lexer("21 * 21");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "21");
+    /// assert_eq!(lexer.next(), Some(Token::Star));
+    /// assert_eq!(lexer.slice(), "*");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "21");
+    /// ```
+    #[token("*")]
+    Star,
+
+    /// The forward slash/divide (`/`) operator.
+    /// 
+    /// ```
+    /// use flycatcher_lexer::Logos;
+    /// use flycatcher_lexer::Token;
+    /// 
+    /// let mut lexer = Token::lexer("42 / 2");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "42");
+    /// assert_eq!(lexer.next(), Some(Token::Slash));
+    /// assert_eq!(lexer.slice(), "/");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "2");
+    /// ```
+    #[token("/")]
+    Slash,
+
+    /// The percent/modulus (`%`) operator.
+    /// 
+    /// ```
+    /// use flycatcher_lexer::Logos;
+    /// use flycatcher_lexer::Token;
+    /// 
+    /// let mut lexer = Token::lexer("21 % 2");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "21");
+    /// assert_eq!(lexer.next(), Some(Token::Percent));
+    /// assert_eq!(lexer.slice(), "%");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "2");
+    /// ```
+    #[token("%")]
+    Percent,
+
     /// A number literal that supports integers and floating point numbers, with an optional
     /// mantissa (exponent).
     /// 

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -17,6 +17,24 @@ pub use logos::{Lexer, Logos};
 #[derive(Clone, Debug, Logos, PartialEq)]
 pub enum Token {
 
+    /// A number literal that supports integers and floating point numbers, with an optional
+    /// mantissa (exponent).
+    /// 
+    /// ```
+    /// use flycatcher_lexer::Logos;
+    /// use flycatcher_lexer::Token;
+    /// 
+    /// let mut lexer = Token::lexer("42 4.2 4.2e1");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "42");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "4.2");
+    /// assert_eq!(lexer.next(), Some(Token::Number));
+    /// assert_eq!(lexer.slice(), "4.2e1");
+    /// ```
+    #[regex("[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?")]
+    Number,
+    
     /// A Flycatcher style string literal, which may start and end with either `'` or `"`.  It
     /// allows escaping characters, but those are not parsed here.
     /// 


### PR DESCRIPTION
This pull request fixes an issue with identifiers where identifiers couldn't contain `_` or `$` after the first character.  It also adds the `+`, `-`, `*`, `/`, `%` and `=` operators.