### PR TITLE
Finish operator precedence, fix operator precedence bugs.

### DIFF
--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -14,7 +14,7 @@ pub use logos::{Lexer, Logos};
 /// assert_eq!(lexer.next(), Some(Token::String));
 /// assert_eq!(lexer.slice(), "'Hello, world!'");
 /// ```
-#[derive(Clone, Debug, Logos, PartialEq)]
+#[derive(Clone, Copy, Debug, Logos, PartialEq)]
 pub enum Token {
 
     /// A period, used for indexing objects.


### PR DESCRIPTION
Operator precedence sometimes worked, but it didn't work under similar conditions:

```flycatcher
test * test + test
```

Which would output:
```
BinaryExpression(
    Multiply,
    IdentifierLiteral(
        "test",
    )
    BinaryExpression(
        Add,
        IdentifierLiteral(
            "test",
        ),
        IdentifierLiteral(
            "test",
        ),
    )
)
```